### PR TITLE
v0.1.6 Fixed callback phase redirect uri issue

### DIFF
--- a/lib/omniauth/psn_oauth2/version.rb
+++ b/lib/omniauth/psn_oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module PsnOauth2
-    VERSION = "0.1.5"
+    VERSION = "0.1.6"
   end
 end


### PR DESCRIPTION
Override build access token method to allow using custom url instead of callback url to remove code and state params added after authorization phase is completed.
Added Authorization headers into options.token_params inside headers key.
